### PR TITLE
Add Api URL response parameter in VHost request

### DIFF
--- a/client/src/main/java/org/qubership/cloud/maas/client/impl/ApiUrlProvider.java
+++ b/client/src/main/java/org/qubership/cloud/maas/client/impl/ApiUrlProvider.java
@@ -52,8 +52,12 @@ public class ApiUrlProvider {
         return rv;
     }
 
-    public String getRabbitVhostGetByClassifierUrl() {
-        return getBaseUrl() + "/rabbit/vhost/get-by-classifier";
+    public String getRabbitVhostGetByClassifierUrl(boolean extended) {
+        String rv = getBaseUrl() + "/rabbit/vhost/get-by-classifier";
+        if (extended) {
+            rv = rv + "?extended=true";
+        }
+        return rv;
     }
 
     private String getBaseUrl() {

--- a/client/src/main/java/org/qubership/cloud/maas/client/impl/rabbit/RabbitMaaSClientImpl.java
+++ b/client/src/main/java/org/qubership/cloud/maas/client/impl/rabbit/RabbitMaaSClientImpl.java
@@ -62,7 +62,7 @@ public class RabbitMaaSClientImpl implements RabbitMaaSClient {
     @Override
     public VHost getVirtualHost(Classifier classifier) {
         log.info("Get vhost by: {}", classifier);
-        return restClient.request(apiProvider.getRabbitVhostGetByClassifierUrl())
+        return restClient.request(apiProvider.getRabbitVhostGetByClassifierUrl(true))
                 .post(classifier)
                 .expect(HTTP_OK)
                 .supressError(HTTP_NOT_FOUND, body -> log.info("Virtual Host not found by {}", classifier))

--- a/client/src/test/java/org/qubership/cloud/maas/client/impl/rabbit/RabbitMaaSClientImplTest.java
+++ b/client/src/test/java/org/qubership/cloud/maas/client/impl/rabbit/RabbitMaaSClientImplTest.java
@@ -111,6 +111,7 @@ class RabbitMaaSClientImplTest {
                 request()
                         .withMethod("POST")
                         .withPath("/api/v2/rabbit/vhost/get-by-classifier")
+                        .withQueryStringParameter("extended", "true")
                         .withHeader("authorization", "Bearer faketoken")
                         .withBody(
                                 json("{\"name\": \"commands\", \"namespace\": \"core-dev\"}",
@@ -123,7 +124,8 @@ class RabbitMaaSClientImplTest {
                                 "    \"vhost\": {\n" +
                                 "        \"cnn\": \"ampq://rabbit-cluster:4321/maas.core-dev.123456\",\n" +
                                 "        \"username\": \"scott\",\n" +
-                                "        \"password\": \"plain:tiger\"\n" +
+                                "        \"password\": \"plain:tiger\",\n" +
+                                "        \"apiUrl\": \"http://rabbit-cluster:15672/api\"\n" +
                                 "    },\n" +
                                 "    \"entities\": {\n" +
                                 "        \"exchanges\": [\n" +
@@ -143,6 +145,7 @@ class RabbitMaaSClientImplTest {
         assertEquals("ampq://rabbit-cluster:4321/maas.core-dev.123456", vhost.getCnn());
         assertEquals("scott", vhost.getUsername());
         assertEquals("tiger", vhost.getPassword());
+        assertEquals("http://rabbit-cluster:15672/api", vhost.getApiUrl());
     }
 
     @Test


### PR DESCRIPTION
### Changelist:
- Add `extended=true` query parameter in `rabbit/vhost/get-by-classifier` request to return `apiUrl` in response. 
- Cover new parameter and response in unit test